### PR TITLE
Chore: Manage rate limit by adding delay on specific host

### DIFF
--- a/404-links.js
+++ b/404-links.js
@@ -8,6 +8,7 @@ let options = {
   configFile: path.resolve(process.cwd(), '.404-links.yml'),
   log: console.log,
   folder: process.cwd(),
+  delay: {},
   ignore: {
     urls: [],
     files: []

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ ignore:
     - https://broken/* # wildcard allows
   files: # Array of markdown file the shouldn't parse
     - ./test.md # Relative path from the folder shared above
+delay:
+  'https://gitlab.com': 500 # Perform a pause of 500ms at each call matching the url
 ```
 
 ### Do you know RestQA ? 


### PR DESCRIPTION
In order to mitigate the rate limit on different we are proposing to manage a delay per request that matching a specific url shared on the `.404-links.yml`

Fix #15

